### PR TITLE
Copilot/fix missing nuget packagee

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/DancingGoat-K13Ecommerce/DancingGoat.csproj
+++ b/examples/DancingGoat-K13Ecommerce/DancingGoat.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="kentico.xperience.azurestorage" VersionOverride="$(XbyKVersion)" />
     <PackageReference Include="kentico.xperience.imageprocessing" VersionOverride="$(XbyKVersion)" />
     <PackageReference Include="kentico.xperience.webapp" VersionOverride="$(XbyKVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>

--- a/examples/DancingGoat-K13Ecommerce/packages.lock.json
+++ b/examples/DancingGoat-K13Ecommerce/packages.lock.json
@@ -1230,11 +1230,20 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
+      "kentico.xperience.ecommerce.common": {
+        "type": "Project",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.Core": "[31.0.0, )",
+          "Microsoft.Extensions.Http": "[8.0.1, )"
+        }
+      },
       "kentico.xperience.k13ecommerce": {
         "type": "Project",
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.Ecommerce.Common": "[3.0.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }

--- a/examples/DancingGoat-K13Ecommerce/packages.lock.json
+++ b/examples/DancingGoat-K13Ecommerce/packages.lock.json
@@ -56,6 +56,16 @@
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
         }
       },
+      "Microsoft.Extensions.Options": {
+        "type": "Direct",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
+          "Microsoft.Extensions.Primitives": "9.0.8"
+        }
+      },
       "Scrutor": {
         "type": "Direct",
         "requested": "[4.2.2, )",
@@ -857,15 +867,6 @@
         "resolved": "8.0.0",
         "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "Microsoft.Extensions.Primitives": "9.0.8"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1229,20 +1230,11 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
-      "kentico.xperience.ecommerce.common": {
-        "type": "Project",
-        "dependencies": {
-          "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Core": "[31.0.0, )",
-          "Microsoft.Extensions.Http": "[8.0.1, )"
-        }
-      },
       "kentico.xperience.k13ecommerce": {
         "type": "Project",
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Ecommerce.Common": "[3.0.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }
@@ -1250,7 +1242,7 @@
       "kentico.xperience.store.rcl": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.K13Ecommerce": "[3.0.0-prerelease-1, )"
+          "Kentico.Xperience.K13Ecommerce": "[3.0.0, )"
         }
       },
       "Duende.AccessTokenManagement.OpenIdConnect": {

--- a/src/Kentico.Xperience.K13Ecommerce/packages.lock.json
+++ b/src/Kentico.Xperience.K13Ecommerce/packages.lock.json
@@ -838,15 +838,6 @@
         "resolved": "8.0.0",
         "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "Microsoft.Extensions.Primitives": "9.0.8"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1178,14 +1169,6 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
-      "kentico.xperience.ecommerce.common": {
-        "type": "Project",
-        "dependencies": {
-          "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Core": "[31.0.0, )",
-          "Microsoft.Extensions.Http": "[8.0.1, )"
-        }
-      },
       "Kentico.Xperience.Core": {
         "type": "CentralTransitive",
         "requested": "[31.0.0, )",
@@ -1209,6 +1192,16 @@
           "Newtonsoft.Json": "13.0.3",
           "System.CodeDom": "8.0.0",
           "System.IO.Hashing": "9.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
+          "Microsoft.Extensions.Primitives": "9.0.8"
         }
       }
     }

--- a/src/Kentico.Xperience.K13Ecommerce/packages.lock.json
+++ b/src/Kentico.Xperience.K13Ecommerce/packages.lock.json
@@ -1169,6 +1169,14 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
+      "kentico.xperience.ecommerce.common": {
+        "type": "Project",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.Core": "[31.0.0, )",
+          "Microsoft.Extensions.Http": "[8.0.1, )"
+        }
+      },
       "Kentico.Xperience.Core": {
         "type": "CentralTransitive",
         "requested": "[31.0.0, )",

--- a/src/Kentico.Xperience.Store.Rcl/packages.lock.json
+++ b/src/Kentico.Xperience.Store.Rcl/packages.lock.json
@@ -771,15 +771,6 @@
         "resolved": "8.0.0",
         "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "Microsoft.Extensions.Primitives": "9.0.8"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1106,20 +1097,11 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
-      "kentico.xperience.ecommerce.common": {
-        "type": "Project",
-        "dependencies": {
-          "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Core": "[31.0.0, )",
-          "Microsoft.Extensions.Http": "[8.0.1, )"
-        }
-      },
       "kentico.xperience.k13ecommerce": {
         "type": "Project",
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Ecommerce.Common": "[2.2.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }
@@ -1188,6 +1170,16 @@
           "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
+          "Microsoft.Extensions.Primitives": "9.0.8"
         }
       },
       "Scrutor": {

--- a/src/Kentico.Xperience.Store.Rcl/packages.lock.json
+++ b/src/Kentico.Xperience.Store.Rcl/packages.lock.json
@@ -1097,11 +1097,20 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
+      "kentico.xperience.ecommerce.common": {
+        "type": "Project",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.Core": "[31.0.0, )",
+          "Microsoft.Extensions.Http": "[8.0.1, )"
+        }
+      },
       "kentico.xperience.k13ecommerce": {
         "type": "Project",
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.Ecommerce.Common": "[3.0.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }

--- a/test/Kentico.Xperience.K13Ecommerce.IntegrationTests/packages.lock.json
+++ b/test/Kentico.Xperience.K13Ecommerce.IntegrationTests/packages.lock.json
@@ -810,15 +810,6 @@
         "resolved": "8.0.0",
         "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "Microsoft.Extensions.Primitives": "9.0.8"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1186,7 +1177,7 @@
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Ecommerce.Common": "[2.2.0, )",
+          "Kentico.Xperience.Ecommerce.Common": "[3.0.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }
@@ -1255,6 +1246,16 @@
           "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
+          "Microsoft.Extensions.Primitives": "9.0.8"
         }
       },
       "Scrutor": {

--- a/test/Kentico.Xperience.K13Ecommerce.UnitTests/packages.lock.json
+++ b/test/Kentico.Xperience.K13Ecommerce.UnitTests/packages.lock.json
@@ -810,15 +810,6 @@
         "resolved": "8.0.0",
         "contentHash": "4pm+XgxSukskwjzDDfSjG4KNUIOdFF2VaqZZDtTzoyQMOVSnlV6ZM8a9aVu5dg9LVZTB//utzSc8fOi0b0Mb2Q=="
       },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "9.0.8",
-        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "Microsoft.Extensions.Primitives": "9.0.8"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1186,7 +1177,7 @@
         "dependencies": {
           "Duende.AccessTokenManagement.OpenIdConnect": "[3.0.1, )",
           "Kentico.Xperience.Admin": "[31.0.0, )",
-          "Kentico.Xperience.Ecommerce.Common": "[2.2.0, )",
+          "Kentico.Xperience.Ecommerce.Common": "[3.0.0, )",
           "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Scrutor": "[4.2.2, )"
         }
@@ -1255,6 +1246,16 @@
           "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "OmTaQ0v4gxGQkehpwWIqPoEiwsPuG/u4HUsbOFoWGx4DKET2AXzopnFe/fE608FIhzc/kcg2p8JdyMRCCUzitQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
+          "Microsoft.Extensions.Primitives": "9.0.8"
         }
       },
       "Scrutor": {


### PR DESCRIPTION
- [x] Initialize git submodule (xperience-by-kentico-ecommerce-common)
- [x] Regenerate all packages.lock.json files with `dotnet restore` (submodule present)
- [x] Verify `dotnet restore --locked-mode` succeeds
- [x] Lock files now include `kentico.xperience.ecommerce.common` project reference